### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 
 
-Available at: [www.rladiesseattle.org](www.rladiesseattle.org)
+Available at: [www.rladiesseattle.org](http://www.rladiesseattle.org)
 
 ## To Update the Site
 


### PR DESCRIPTION
adds `http://` to the link to the site so that GitHub does not preface it with the GitHub repo location.